### PR TITLE
Fix panel generation and add synthesizer tests

### DIFF
--- a/tests/test_synthesizer.py
+++ b/tests/test_synthesizer.py
@@ -1,0 +1,58 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import pandas as pd
+from credit_data_synthesizer import CreditDataSynthesizer, default_group_profiles
+
+N_GROUPS = 3
+CONTRACTS = 100
+N_SAFRAS = 12
+
+
+def make_synth():
+    profiles = default_group_profiles(N_GROUPS)
+    return CreditDataSynthesizer(
+        group_profiles=profiles,
+        contracts_per_group=CONTRACTS,
+        n_safras=N_SAFRAS,
+        random_seed=42,
+    )
+
+
+def test_snapshot_size():
+    synth = make_synth()
+    snap, panel, trace = synth.generate()
+    assert len(snap) == N_GROUPS * CONTRACTS
+
+
+def test_panel_safras_count():
+    synth = make_synth()
+    snap, panel, trace = synth.generate()
+    assert panel["safra"].nunique() == N_SAFRAS
+
+
+def test_unique_ids():
+    synth = make_synth()
+    snap, panel, trace = synth.generate()
+    assert snap["id_contrato"].is_unique
+    assert panel.groupby("id_contrato")["id_cliente"].nunique().max() == 1
+
+
+def test_features_presence():
+    synth = make_synth()
+    snap, panel, trace = synth.generate()
+    required = {
+        "dias_atraso",
+        "nivel_refinanciamento",
+        "saldo_devedor",
+        "valor_parcela",
+        "prazo_meses",
+        "taxa_juros_anual_pct",
+    }
+    assert required.issubset(panel.columns)
+
+
+def test_targets_flagged():
+    synth = make_synth()
+    snap, panel, trace = synth.generate()
+    assert snap["ever90m12"].sum() > 0


### PR DESCRIPTION
## Summary
- implement monthly panel evolution respecting `n_safras`
- add refinancing and renegotiation logic
- compute `ever90m12`, `over90m12` and curing flag
- expand contract sampling with extra financial features
- add pytest suite covering synthesizer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1b7d075883219cb2899752cc7575