### PR TITLE
Enhance transition matrices and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ synth = CreditDataSynthesizer(
 df_snapshot, df_panel, df_trace = synth.generate()
 ```
 
+Exemplo definindo uma matriz BASE personalizada:
+
+```python
+import numpy as np
+from creditlab import default_group_profiles
+
+base = np.eye(5)
+synth = CreditDataSynthesizer(
+    group_profiles=default_group_profiles(3),
+    base_matrix=base,
+)
+```
+
 ---
 
 

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+from credit_data_synthesizer import (
+    generate_transition_matrix,
+    DEFAULT_BUCKETS,
+    _risk_score,
+)
+
+
+def test_matrix_rowsum():
+    mat = generate_transition_matrix(DEFAULT_BUCKETS, sev=0.5)
+    assert np.allclose(mat.sum(axis=1), 1.0)
+
+
+def test_min_diag():
+    mat = generate_transition_matrix(DEFAULT_BUCKETS, sev=1.0)
+    assert (np.diag(mat) >= 0.01).all()
+
+
+def test_shape():
+    buckets = [0, 15, 30, 60, 90, 120]
+    base = np.eye(len(buckets))
+    mat = generate_transition_matrix(buckets, sev=0.3, base_mat=base)
+    assert mat.shape == (len(buckets), len(buckets))
+
+
+def test_monotone_risk():
+    mat1 = generate_transition_matrix(DEFAULT_BUCKETS, sev=0.2)
+    mat2 = generate_transition_matrix(DEFAULT_BUCKETS, sev=0.8)
+    assert _risk_score(mat2, DEFAULT_BUCKETS) > _risk_score(mat1, DEFAULT_BUCKETS)


### PR DESCRIPTION
## Summary
- support custom base transition matrices and severity scaling
- expose constant BASE_5x5 and new _risk_score helper
- update synthesizer docs and README with base matrix example
- add transition matrix unit tests

## Testing
- `bash tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d3b1d23248321851750b787f0eff4