### PR TITLE
Refactor client registry and update consistency tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ synth = CreditDataSynthesizer(
 )
 
 df_snapshot, df_panel, df_trace = synth.generate()
+df_panel = df_panel.merge(synth.clients, on="id_cliente")
 ```
 
 Exemplo definindo uma matriz BASE personalizada:


### PR DESCRIPTION
## Summary
- implement `_build_clients` helper and expose `clients` property
- ensure unique contract per client/safra and immutable contract start dates
- adjust `_generate_snapshot` with new client flow
- update README usage example with `panel.merge(synth.clients)`
- revise consistency tests to use pytest fixtures

## Testing
- `pip install pandas numpy --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d58c6a85083219fbf6a108988a3b4