### PR TITLE
Implement refinancing probability and multi-contract features

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,12 @@ synth = CreditDataSynthesizer(
     contracts_per_group=5_000,
     n_safras=36,
     force_event_rate=True,      # balance after generation
-    target_ratio=0.10,
+    target_ratio=0.08,
     buckets=[0,15,30,60,90,120,180,240,360],
+    p_accept_refin=0.5,
+    max_simultaneous_contracts=3,
+    tol_pp=0.5,
+    verbose=True,
 )
 _, panel, _ = synth.generate()
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+pip install -q pandas numpy matplotlib
 mkdir -p tests/test_results
 
 pytest -vv --tb=long tests > tests/test_results/test_results.txt

--- a/tests/test_buckets.py
+++ b/tests/test_buckets.py
@@ -38,7 +38,7 @@ def test_ever360():
     n = len(CUSTOM_BUCKETS)
     tm = np.zeros((n, n))
     tm[:, CUSTOM_BUCKETS.index(360)] = 1.0
-    gp = GroupProfile(name="G", pd_base=0.12, refin_prob=0.0, reneg_prob_exog=0.0, transition_matrix=tm)
+    gp = GroupProfile(name="G", pd_base=0.12, p_accept_refin=0.0, reneg_prob_exog=0.0, transition_matrix=tm)
     synth = CreditDataSynthesizer(
         group_profiles=[gp],
         contracts_per_group=1,

--- a/tests/test_churn.py
+++ b/tests/test_churn.py
@@ -24,10 +24,11 @@ def test_start_leq_dataref():
     assert (panel["data_inicio_contrato"] <= panel["data_ref"]).all()
 
 
-def test_one_active_contract_per_client():
+def test_start_month_unique_per_contract():
     synth = make_synth()
-    _, panel, _ = synth.generate()
-    assert not panel.duplicated(["id_cliente", "safra"]).any()
+    snap, _, _ = synth.generate()
+    pairs = snap.assign(m=snap["data_inicio_contrato"].dt.strftime("%Y%m"))
+    assert not pairs.duplicated(["id_cliente", "m"]).any()
 
 
 def test_preserve_rank_after_sampling():

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -31,8 +31,10 @@ def test_start_before_safra(panel: pd.DataFrame):
     assert (panel["data_inicio_contrato"] <= panel["data_ref"]).all()
 
 
-def test_unique_client_month(panel: pd.DataFrame):
-    assert not panel.duplicated(["id_cliente", "safra"]).any()
+def test_unique_client_start_month(panel: pd.DataFrame):
+    snap = panel[panel["data_ref"] == panel["data_ref"].min()].copy()
+    pairs = snap.assign(m=snap["data_inicio_contrato"].dt.strftime("%Y%m"))
+    assert not pairs.duplicated(["id_cliente", "m"]).any()
 
 
 def test_unique_birthdate(synth: CreditDataSynthesizer):

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -1,0 +1,62 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import logging
+import numpy as np
+from credit_data_synthesizer import CreditDataSynthesizer, GroupProfile, default_group_profiles, DEFAULT_BUCKETS
+
+
+def test_refin_probability():
+    tm = np.eye(len(DEFAULT_BUCKETS))
+    gp0 = GroupProfile(name="G", pd_base=0.06, p_accept_refin=0.0, reneg_prob_exog=0.0, transition_matrix=tm)
+    synth0 = CreditDataSynthesizer(group_profiles=[gp0], contracts_per_group=40, n_safras=6, random_seed=0, kernel_trick=False, force_event_rate=False)
+    _, panel0, _ = synth0.generate()
+    assert panel0["nivel_refinanciamento"].sum() == 0
+
+    gp1 = GroupProfile(name="G", pd_base=0.06, p_accept_refin=1.0, reneg_prob_exog=0.0, transition_matrix=tm)
+    synth1 = CreditDataSynthesizer(group_profiles=[gp1], contracts_per_group=40, n_safras=6, random_seed=1, kernel_trick=False, force_event_rate=False)
+    _, panel1, _ = synth1.generate()
+    assert panel1["nivel_refinanciamento"].sum() > 0
+
+
+def test_reneg_stage1():
+    n = len(DEFAULT_BUCKETS)
+    tm = np.zeros((n, n))
+    idx15 = DEFAULT_BUCKETS.index(15)
+    tm[:, idx15] = 1.0
+    gp = GroupProfile(name="G", pd_base=0.12, p_accept_refin=0.0, reneg_prob_exog=0.2, transition_matrix=tm)
+    synth = CreditDataSynthesizer(group_profiles=[gp], contracts_per_group=40, n_safras=6, random_seed=2, kernel_trick=False, force_event_rate=False)
+    _, _, trace = synth.generate()
+    assert len(trace) > 0
+
+
+def test_multi_contracts():
+    synth = CreditDataSynthesizer(
+        group_profiles=default_group_profiles(2),
+        contracts_per_group=30,
+        n_safras=4,
+        random_seed=3,
+        kernel_trick=False,
+        force_event_rate=False,
+        max_simultaneous_contracts=3,
+    )
+    snap, _, _ = synth.generate()
+    pairs = snap.assign(m=snap["data_inicio_contrato"].dt.strftime("%Y%m"))
+    assert len(pairs) == len(pairs.drop_duplicates(["id_cliente", "m"]))
+
+
+def test_post_sampling_ratio(caplog):
+    caplog.set_level(logging.WARNING)
+    synth = CreditDataSynthesizer(
+        group_profiles=default_group_profiles(2),
+        contracts_per_group=200,
+        n_safras=6,
+        random_seed=4,
+        kernel_trick=False,
+        target_ratio=0.33,
+        tol_pp=0.5,
+    )
+    _, panel, _ = synth.generate()
+    real = panel["ever90m12"].mean()
+    assert abs(real - 0.33) <= 0.005

--- a/tests/test_realismo.py
+++ b/tests/test_realismo.py
@@ -20,7 +20,7 @@ def test_transition_matrix_rowsum():
 def test_targets_include_reneg():
     tm = np.zeros((5, 5))
     tm[:, 3] = 1.0
-    gp = GroupProfile(name="G", pd_base=0.12, refin_prob=0.0, reneg_prob_exog=1.0, transition_matrix=tm)
+    gp = GroupProfile(name="G", pd_base=0.12, p_accept_refin=0.0, reneg_prob_exog=1.0, transition_matrix=tm)
     synth = CreditDataSynthesizer(group_profiles=[gp], contracts_per_group=1, n_safras=3, random_seed=0, kernel_trick=False)
     snap, panel, trace = synth.generate()
     assert len(trace) > 0


### PR DESCRIPTION
## Summary
- add `p_accept_refin` to group profile
- refine renegotiation logic with bucket factors
- support multiple contracts per client
- recompute targets after sampling
- enhance sampler to warn when undersampling insufficient
- add verbose logging and update README
- new tests covering refinancing probability, reneg tier, multi-contracts and sampling ratio

## Testing
- `bash tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e65f1f9fc8321a262b9bf3d42d4ac