### PR TITLE
Add rebin/drop options to transition matrix

### DIFF
--- a/tests/test_tm_options.py
+++ b/tests/test_tm_options.py
@@ -1,0 +1,65 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+from transition_matrix_estimator import TransitionMatrixLearner
+
+
+def test_rebin_moves_counts():
+    counts = np.array([
+        [1, 1, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 1],
+        [0, 0, 0, 1],
+    ], dtype=float)
+    learner = TransitionMatrixLearner(
+        buckets=[0, 30, 60, 90], auto_rebin=True, min_count=2
+    )
+    total = counts.sum()
+    learner._clean_matrix(counts)
+    assert counts.sum() == total
+
+
+def test_drop_updates_labels():
+    import pandas as pd
+    df = pd.DataFrame(
+        {
+            "id": [1, 1],
+            "data_ref": pd.to_datetime(["2021-01-01", "2021-02-01"]),
+            "delay": [0, 0],
+        }
+    )
+    learner = TransitionMatrixLearner(
+        buckets=[0, 30, 60], drop_empty=True, min_count=1
+    )
+    learner.fit(df, id_col="id", time_col="data_ref", bucket_col="delay")
+    mat = learner.get_matrix()
+    assert len(learner.cleaned_buckets) == mat.shape[0]
+
+
+def test_no_flat_rows():
+    import pandas as pd
+    df = pd.DataFrame(
+        {
+            "id": [1, 1, 2, 2, 3, 3, 3],
+            "data_ref": pd.to_datetime(
+                [
+                    "2021-01-01",
+                    "2021-02-01",
+                    "2021-01-01",
+                    "2021-02-01",
+                    "2021-01-01",
+                    "2021-02-01",
+                    "2021-03-01",
+                ]
+            ),
+            "delay": [0, 30, 0, 0, 60, 90, 90],
+        }
+    )
+    learner = TransitionMatrixLearner(
+        buckets=[0, 30, 60, 90], drop_empty=True, min_count=1
+    )
+    learner.fit(df, id_col="id", time_col="data_ref", bucket_col="delay")
+    mat = learner.get_matrix()
+    assert (mat.std(axis=1) > 0).all()

--- a/transition_matrix_estimator.py
+++ b/transition_matrix_estimator.py
@@ -18,10 +18,14 @@ from __future__ import annotations
 
 from collections import defaultdict
 from typing import Dict, List, Tuple
+import logging
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
+
+logger = logging.getLogger("creditlab.tm")
+logger.setLevel(logging.INFO)
 
 __all__ = ["TransitionMatrixLearner"]
 
@@ -29,13 +33,30 @@ __all__ = ["TransitionMatrixLearner"]
 class TransitionMatrixLearner:
     """Learn transition matrices and provide quick seaborn visualisation."""
 
-    def __init__(self, *, buckets: List[int], alpha: float = 1.0):
+    def __init__(
+        self,
+        *,
+        buckets: List[int],
+        alpha: float = 1.0,
+        auto_rebin: bool = False,
+        drop_empty: bool = False,
+        min_count: int = 10,
+        rebin_window: int = 7,
+    ):
+        if auto_rebin and drop_empty:
+            raise ValueError("Only one of auto_rebin or drop_empty can be True")
         self.buckets = sorted(buckets)
-        self.alpha = alpha  # Laplace smoothing
+        self.alpha = alpha
+        self.auto_rebin = auto_rebin
+        self.drop_empty = drop_empty
+        self.min_count = int(min_count)
+        self.rebin_window = int(rebin_window)
         self.n = len(self.buckets)
+        self.cleaned_buckets: List[int] = self.buckets.copy()
         self._mat_global: np.ndarray | None = None
         self._mat_by_gh: Dict[str, np.ndarray] = {}
         self._mat_by_stage: Dict[int, np.ndarray] = {}
+        self.logger = logger.getChild(self.__class__.__name__)
 
     # ------------------------------------------------------------------
     def fit(
@@ -52,10 +73,6 @@ class TransitionMatrixLearner:
         panel[time_col] = pd.to_datetime(panel[time_col])
         panel = panel.sort_values([id_col, time_col])
 
-        def bucket_idx(val: int) -> int:
-            idx = np.searchsorted(self.buckets, val, side="right") - 1
-            return max(0, min(idx, self.n - 1))
-
         # create shifted df to align t and t+1
         shifted = panel.copy()
         shifted[time_col] += pd.DateOffset(months=1)
@@ -67,33 +84,86 @@ class TransitionMatrixLearner:
         )
 
         # global matrix
-        self._mat_global = self._count_to_matrix(
+        counts_global = self._count_matrix(
             merged[bucket_col + "_t"], merged[bucket_col + "_t1"]
         )
+        self._mat_global = self._clean_matrix(counts_global)
 
         # by GH
         if group_col:
             for gh, grp in merged.groupby(group_col + "_t"):
-                self._mat_by_gh[gh] = self._count_to_matrix(
+                counts = self._count_matrix(
                     grp[bucket_col + "_t"], grp[bucket_col + "_t1"]
                 )
+                self._mat_by_gh[gh] = self._clean_matrix(counts)
 
         # by stage (current bucket)
         for idx, grp in merged.groupby(bucket_col + "_t"):
-            self._mat_by_stage[int(idx)] = self._count_to_matrix(
+            counts = self._count_matrix(
                 grp[bucket_col + "_t"], grp[bucket_col + "_t1"]
             )
+            self._mat_by_stage[int(idx)] = self._clean_matrix(counts)
         return self
 
     # ------------------------------------------------------------------
-    def _count_to_matrix(self, col_from: pd.Series, col_to: pd.Series) -> np.ndarray:
-        mat = np.zeros((self.n, self.n), dtype=float) + self.alpha  # Laplace
+    def _count_matrix(self, col_from: pd.Series, col_to: pd.Series) -> np.ndarray:
+        mat = np.zeros((self.n, self.n), dtype=float)
         for src, dst in zip(col_from, col_to):
             i = np.searchsorted(self.buckets, src, side="right") - 1
             j = np.searchsorted(self.buckets, dst, side="right") - 1
             mat[i, j] += 1
-        mat /= mat.sum(axis=1, keepdims=True)
         return mat
+
+    # ------------------------------------------------------------------
+    def _clean_matrix(self, mat: np.ndarray) -> np.ndarray:
+        row_sums = mat.sum(axis=1)
+
+        if self.auto_rebin:
+            non_empty = [i for i, s in enumerate(row_sums) if s >= self.min_count]
+            for i, s in enumerate(row_sums):
+                if s < self.min_count:
+                    if not non_empty:
+                        continue
+                    candidates = [x for x in non_empty if abs(self.buckets[x] - self.buckets[i]) <= self.rebin_window]
+                    if not candidates:
+                        candidates = non_empty
+                    j = min(candidates, key=lambda x: abs(self.buckets[x] - self.buckets[i]))
+                    mat[j] += mat[i]
+                    mat[:, j] += mat[:, i]
+                    mat[i] = 0
+                    mat[:, i] = 0
+                    row_sums[j] += s
+                    row_sums[i] = 0
+                    self.logger.info(
+                        "[TM] Empty bucket %d -> re-binned into %d (%d transitions moved)",
+                        self.buckets[i],
+                        self.buckets[j],
+                        int(s),
+                    )
+            # buckets unchanged
+            self.cleaned_buckets = self.buckets.copy()
+
+        elif self.drop_empty:
+            keep = [s >= self.min_count for s in row_sums]
+            for idx, (k, s) in enumerate(zip(keep, row_sums)):
+                if not k:
+                    self.logger.info(
+                        "[TM] Dropped bucket %d (total count=%d)",
+                        self.buckets[idx],
+                        int(s),
+                    )
+            mat = mat[np.ix_(keep, keep)]
+            self.cleaned_buckets = [b for b, k in zip(self.buckets, keep) if k]
+        else:
+            self.cleaned_buckets = self.buckets.copy()
+
+        # apply Laplace only to non-empty rows
+        final = np.zeros_like(mat, dtype=float)
+        for i in range(mat.shape[0]):
+            if mat[i].sum() > 0:
+                row = mat[i] + self.alpha
+                final[i] = row / row.sum()
+        return final
 
     # ------------------------------------------------------------------
     def get_matrix(self, *, gh: str | None = None, stage: int | None = None) -> np.ndarray:
@@ -127,7 +197,7 @@ class TransitionMatrixLearner:
 
         figs: List[plt.Figure] = []
         cmap = sns.color_palette("Blues", as_cmap=True)
-        xt = yt = [str(b) for b in self.buckets]
+        xt = yt = [str(b) for b in self.cleaned_buckets]
 
         def _prep(mat: np.ndarray, thr: float = 0.5) -> pd.DataFrame:
             """


### PR DESCRIPTION
## Summary
- enhance `TransitionMatrixLearner` with `auto_rebin` and `drop_empty` options
- log adjustments and track `cleaned_buckets`
- ensure heatmaps use updated bucket labels
- cover new behaviour with tests

## Testing
- `./tests/run_tests.sh` *(fails: pip install requires network)*

------
https://chatgpt.com/codex/tasks/task_e_686ec27ee0188321b95c82f9e4007aeb